### PR TITLE
Change manager basebox to trusty64

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,16 +6,16 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.define :manager, :autostart => true do |node|
-    node.vm.box = 'debian/stretch64'
+    node.vm.box = 'ubuntu/trusty64'
     node.vm.hostname = "manager"
     node.vm.network :private_network, ip: "10.0.11.10", hostsupdater: "skip"
-    node.vm.synced_folder ".", "/vagrant", type: "virtualbox"
     node.vm.provider "virtualbox" do |vb|
       vb.memory = "512"
       vb.gui = false
       vb.customize ['modifyvm', :id, '--natdnshostresolver1', 'on']
     end
-    # node.vm.provision :shell, path: "vagrant/test.sh", privileged: false
+
+    node.vm.provision :shell, path: "vagrant/upgrade_ansible.sh", privileged: false
     node.vm.provision "ansible_local" do |ansible|
       ansible.playbook       = "site.yml"
       ansible.verbose        = true
@@ -29,7 +29,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     node.vm.box = 'ubuntu/trusty64'
     node.vm.hostname = 'test'
     node.vm.network :private_network, ip: "10.0.11.11", hostsupdater: "skip"
-    node.vm.synced_folder ".", "/vagrant", type: "virtualbox"
     node.vm.provider "virtualbox" do |vb|
       vb.memory = "1024"
       vb.gui = false

--- a/roles/fish/tasks/main.yml
+++ b/roles/fish/tasks/main.yml
@@ -10,3 +10,13 @@
   user:
     name: "{{ user }}"
     shell: /usr/bin/fish
+
+
+- name: Create fish config dir
+  file: >
+    path='{{ home_dir }}/.config/fish/' state=directory
+
+- name: set /vagrant as default cd directory in config.fish
+  copy:
+    dest: '{{ home_dir }}/.config/fish/config.fish'
+    content:  "cd /vagrant"

--- a/roles/manager/tasks/main.yml
+++ b/roles/manager/tasks/main.yml
@@ -50,4 +50,5 @@
   blockinfile:
     dest: '{{ home_dir }}/.bashrc'
     block:  |
+      cd /vagrant
       export ANSIBLE_VAULT_PASSWORD_FILE=/vagrant/ansible/vault-pass.txt

--- a/vagrant/upgrade_ansible.sh
+++ b/vagrant/upgrade_ansible.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+sudo apt update
+sudo apt install -y python-pip
+sudo pip install pip --upgrade
+sudo pip install ansible>=2.4


### PR DESCRIPTION
- added upgrade_ansible.sh to preinstall ansible2.4 from shell before real
  provisioning starts - enables manager provisioning via vagrant.
    (previously it returned syntax errors on the playbook due to unsupported
    included_tasks in default (2.2) ansible version)

- changed basebox mostly due to weird problems with synced_folder setup; had some issues with mounting it as virtualbox, when going with default on debian box it defaulted to rsync, and using rsync it couldn't complete the provisioning because of no access to the ssh key.

- also set /vagrant as default cd in fish.config and .bashrc to improve usability

(fixes #1)

I only tested it on linux, and have no way of testing it on mac any time soon. 
Could someone please run the 'vagrant up' there and check if it works?