### PR TITLE
Configure bash to stop on failure

### DIFF
--- a/vagrant/test.sh
+++ b/vagrant/test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -eo pipefail
+
 sudo apt-get update
 sudo apt-get -y upgrade
 


### PR DESCRIPTION
Without `set -eo pipefail` if any command fails, the script will continue as if nothing had happened.